### PR TITLE
Report extra

### DIFF
--- a/themes/default/views/reports_view.php
+++ b/themes/default/views/reports_view.php
@@ -72,6 +72,9 @@
 		</div>
 		
 		<?php
+            // Action::report_extra - Allows you to target an individual report right after the description
+            Event::run('ushahidi_action.report_extra', $incident_id);
+
 			// Filter::comments_block - The block that contains posted comments
 			Event::run('ushahidi_filter.comment_block', $comments);
 			echo $comments;


### PR DESCRIPTION
The report_extra action is listed as existing in the API documentation, but appears to be missing from themes/default/views/reports_view.php.

I'd really like to use it so I've added it in.

Also note that the API says that the report_extra action receives the report object, the version I'm requesting only gives the $incident_id.

george
