### PR TITLE
Hidden categories

### DIFF
--- a/application/controllers/admin/reports.php
+++ b/application/controllers/admin/reports.php
@@ -1563,7 +1563,7 @@ class Reports_Controller extends Admin_Controller
     private function _get_categories()
     {
         $categories = ORM::factory('category')
-            ->where('category_visible', '1')
+            //->where('category_visible', '1')
             ->where('parent_id', '0')
             ->orderby('category_title', 'ASC')
             ->find_all();


### PR DESCRIPTION
Hooray 1am pull requests.

Commenting out one line of code makes it possible for administrators to view categories that are marked as not-visible.  This effectively implements admin-only categories that can be extremely useful for internal tracking of messages for things such as translation status, geolocation status, and the like.

george
