### PR TITLE
FIXED: SwiftMailSender useing SMTP mode have warning message.

### DIFF
--- a/system/vendor/swift/Swift.php
+++ b/system/vendor/swift/Swift.php
@@ -274,7 +274,7 @@ class Swift
     for ($i = 1, $len = count($list); $i < $len; $i++)
     {
       $extension = substr($list[$i], 4);
-      $attributes = split("[ =]", $extension);
+      $attributes = explode("[ =]", $extension);
       $this->connection->setExtension($attributes[0], (isset($attributes[1]) ? array_slice($attributes, 1) : array()));
     }
   }


### PR DESCRIPTION
Show the Function split() is deprecated.
