### PR TITLE
Add an option to disable the scheduler JS callback

### DIFF
--- a/application/controllers/admin/settings.php
+++ b/application/controllers/admin/settings.php
@@ -63,6 +63,7 @@ class Settings_Controller extends Admin_Controller
 			'allow_comments' => '',
 			'allow_feed' => '',
 			'allow_stat_sharing' => '',
+			'enable_scheduler_js' => '',
 			'allow_clustering' => '',
 			'cache_pages' => '',
 			'cache_pages_lifetime' => '',
@@ -112,6 +113,7 @@ class Settings_Controller extends Admin_Controller
 			$post->add_rules('allow_comments','required','between[0,2]');
 			$post->add_rules('allow_feed','required','between[0,1]');
 			$post->add_rules('allow_stat_sharing','required','between[0,1]');
+			$post->add_rules('enable_scheduler_js','required','between[0,1]');
 			$post->add_rules('allow_clustering','required','between[0,1]');
 			$post->add_rules('cache_pages','required','between[0,1]');
 			$post->add_rules('cache_pages_lifetime','required','in_array[300,600,900,1800]');
@@ -154,6 +156,7 @@ class Settings_Controller extends Admin_Controller
 				$settings->allow_comments = $post->allow_comments;
 				$settings->allow_feed = $post->allow_feed;
 				$settings->allow_stat_sharing = $post->allow_stat_sharing;
+				$settings->enable_scheduler_js = $post->enable_scheduler_js;
 				$settings->allow_clustering = $post->allow_clustering;
 				$settings->cache_pages = $post->cache_pages;
 				$settings->cache_pages_lifetime = $post->cache_pages_lifetime;
@@ -274,6 +277,7 @@ class Settings_Controller extends Admin_Controller
 				'allow_comments' => $settings->allow_comments,
 				'allow_feed' => $settings->allow_feed,
 				'allow_stat_sharing' => $settings->allow_stat_sharing,
+				'enable_scheduler_js' => $settings->enable_scheduler_js,
 				'allow_clustering' => $settings->allow_clustering,
 				'cache_pages' => $settings->cache_pages,
 				'cache_pages_lifetime' => $settings->cache_pages_lifetime,

--- a/application/controllers/main.php
+++ b/application/controllers/main.php
@@ -141,6 +141,11 @@ class Main_Controller extends Template_Controller {
 			? Stats_Model::get_javascript()
 			: '';
 		
+		// Add scheduler JS, if enabled
+		$this->template->footer->scheduler = ( Kohana::config('settings.enable_scheduler_js') == 1)
+			? Scheduler_Model::get_javascript()
+			: '';
+		
 		// add copyright info
 		$this->template->footer->site_copyright_statement = '';
 		$site_copyright_statement = trim(Kohana::config('settings.site_copyright_statement'));

--- a/application/hooks/2_settings.php
+++ b/application/hooks/2_settings.php
@@ -34,6 +34,7 @@ Kohana::config_set('settings.allow_reports', $settings->allow_reports);
 Kohana::config_set('settings.allow_comments', $settings->allow_comments);
 Kohana::config_set('settings.allow_feed', $settings->allow_feed);
 Kohana::config_set('settings.allow_stat_sharing', $settings->allow_stat_sharing);
+Kohana::config_set('settings.enable_scheduler_js', $settings->enable_scheduler_js);
 Kohana::config_set('settings.allow_clustering', $settings->allow_clustering);
 Kohana::config_set('settings.sms_provider', $settings->sms_provider);
 Kohana::config_set('settings.sms_no1', $settings->sms_no1);

--- a/application/i18n/en_US/settings.php
+++ b/application/i18n/en_US/settings.php
@@ -147,6 +147,7 @@
 		'email_alerts' => 'Alerts Email Address',
 		'email_notice' => '<span>In order to receive reports by email, please configure your email account settings.</span>',
 		'email_site' => 'Site Email Address',
+		'enable_scheduler_js' => 'Run Scheduler on every page load',
 		'google_analytics' => 'Google Analytics',
 		'google_analytics_example' => 'Web Property ID - Formato: UA-XXXXX-XX',
 		'items_per_page' => 'Items Per Page - Front End',

--- a/application/i18n/en_US/tooltips.php
+++ b/application/i18n/en_US/tooltips.php
@@ -53,6 +53,7 @@
 	'settings_display_howtohelp' => 'Turn the How to Help Tab on or off on the main site.',
 	'settings_display_items_per_page' => 'This is the number of reports displayed per page on the main site.',
 	'settings_display_items_per_page_admin' => 'This is the number of reports displayed per page on the admin Back End.',
+	'settings_enable_scheduler_js' => 'Include JS callback to run the scheduler on every page',
 	'settings_flsms_download' => 'This is the hub for incoming messages',
 	'settings_flsms_synchronize' => 'This synchronizes the messages in the hub with the Ushahidi platform',
 	'settings_flsms_text_1' => 'Phone numbers through which the text messages are received',

--- a/application/models/scheduler.php
+++ b/application/models/scheduler.php
@@ -20,4 +20,14 @@ class Scheduler_Model extends ORM
 	
 	// Database table name
 	protected $table_name = 'scheduler';
+	
+	/*
+	* Get Scheduler JS for inclusion in footer
+	*/
+	static function get_javascript()
+	{
+		$tag = '<!-- Task Scheduler --><script type="text/javascript">$(document).ready(function(){$(\'#schedulerholder\').html(\'<img src="<?php echo url::base(); ?>scheduler" />\');});</script><div id="schedulerholder"></div><!-- End Task Scheduler -->';
+		
+		return $tag;
+	}
 }

--- a/application/views/admin/site.php
+++ b/application/views/admin/site.php
@@ -165,6 +165,12 @@
 							</span>
 						</div>
 						<div class="row">
+							<h4><a href="#" class="tooltip" title="<?php echo Kohana::lang("tooltips.settings_enable_scheduler_js"); ?>"><?php echo Kohana::lang('settings.site.enable_scheduler_js');?></a></h4>
+							<span class="sel-holder">
+								<?php print form::dropdown('enable_scheduler_js', $yesno_array, $form['enable_scheduler_js']); ?>
+							</span>
+						</div>
+						<div class="row">
 							<h4><a href="#" class="tooltip" title="<?php echo Kohana::lang("tooltips.settings_allow_clustering"); ?>"><?php echo Kohana::lang('settings.site.allow_clustering');?></a></h4>
 							<span class="sel-holder">
 								<?php print form::dropdown('allow_clustering', $yesno_array, $form['allow_clustering']); ?>

--- a/sql/upgrade66-67.sql
+++ b/sql/upgrade66-67.sql
@@ -1,0 +1,3 @@
+﻿ALTER TABLE `settings` ADD `enable_scheduler_js` tinyint(4) NOT NULL DEFAULT '0';
+
+UPDATE `settings` SET `db_version` = '67' WHERE `id`=1 LIMIT 1;

--- a/sql/ushahidi.sql
+++ b/sql/ushahidi.sql
@@ -1454,11 +1454,11 @@ CREATE TABLE IF NOT EXISTS `badge_users` (
 * Add field to table `settings`
 */
 ALTER TABLE `settings` ADD `allow_alerts` tinyint(4) NOT NULL DEFAULT '0';
-
+ALTER TABLE `settings` ADD `enable_scheduler_js` tinyint(4) NOT NULL DEFAULT '0';
 
 /**
 * Version information for table `settings`
 * 
 */
 UPDATE `settings` SET `ushahidi_version` = '2.1' WHERE `id`=1 LIMIT 1;
-UPDATE `settings` SET `db_version` = '66' WHERE `id`=1 LIMIT 1;
+UPDATE `settings` SET `db_version` = '67' WHERE `id`=1 LIMIT 1;

--- a/themes/default/views/footer.php
+++ b/themes/default/views/footer.php
@@ -51,8 +51,7 @@
  
 	<?php echo $ushahidi_stats; ?>
 	<?php echo $google_analytics; ?>
-	
-	<!-- Task Scheduler --><script type="text/javascript">$(document).ready(function(){$('#schedulerholder').html('<img src="<?php echo url::base(); ?>scheduler" />');});</script><div id="schedulerholder"></div><!-- End Task Scheduler -->
+	<?php echo $scheduler; ?>
  
 	<?php
 	// Action::main_footer - Add items before the </body> tag


### PR DESCRIPTION
The scheduler JS callback runs on every page load, this would be better run on cron.
This commit adds a setting to not include the JS.
