### PR TITLE
Fixed bug in s_twitter.php related to https://bugs.php.net/bug.php?id=46730

### DIFF
--- a/application/controllers/scheduler/s_twitter.php
+++ b/application/controllers/scheduler/s_twitter.php
@@ -138,7 +138,7 @@ class S_Twitter_Controller extends Controller {
 
 			if ($reporter->level_id > 1 && 
 				count(ORM::factory("message")
-					->where("service_messageid = '".$tweet->{'id'}."'")
+					->where("service_messageid = '".$tweet->{'id_str'}."'")
 					->find_all()) == 0)
 			{
 				// Save Tweet as Message
@@ -153,7 +153,7 @@ class S_Twitter_Controller extends Controller {
 				$message->message_type = 1; // Inbox
 				$tweet_date = date("Y-m-d H:i:s",strtotime($tweet->{'created_at'}));
 				$message->message_date = $tweet_date;
-				$message->service_messageid = $tweet->{'id'};
+				$message->service_messageid = $tweet->{'id_str'};
 				$message->save();
 				
 				// Action::message_twitter_add - Twitter Message Received!


### PR DESCRIPTION
The twitter id is integer >  2147483647 . This generates an error using json_decode, generating 2147483647 to all id.

See https://bugs.php.net/bug.php?id=46730

Use: $tweet->{'id_str'} instead of $tweet->{'id'}
