### PR TITLE
Replace file_get_contents with remote::get in Geocoder

### DIFF
--- a/application/libraries/Geocoder.php
+++ b/application/libraries/Geocoder.php
@@ -28,16 +28,15 @@ class Geocoder_Core {
 			$api_key = Kohana::config('settings.api_google');
 			if ($api_key)
 			{
-				$base_url = "http://" . GEOCODER_GOOGLE . "/maps/geo?output=xml" . "&key=" . api_key;
+				$base_url = 'http://'.GEOCODER_GOOGLE.'/maps/geo?output=xml'.'&key='.$api_key;
 				
 				// Deal with the geocoder timing out during operations
 				$geocode_pending = true;
 				
 				while ($geocode_pending) {
-					$request_url = $base_url . "&q=" . urlencode($address);
+					$request_url = $base_url.'&q='.urlencode($address);
 
-					//$xml = simplexml_load_file(utf8_encode($request_url)) or die("url not loading");
-					$page = file_get_contents($request_url);
+					$page = remote::get($request_url);
 					$page = utf8_encode($page);
 					$xml = new SimpleXMLElement($page);
 
@@ -47,15 +46,15 @@ class Geocoder_Core {
 						// Successful geocode
 						$geocode_pending = false;
 						$coordinates = $xml->Response->Placemark->Point->coordinates;
-						$coordinatesSplit = explode(",", $coordinates);
+						$coordinates_split = explode(',', $coordinates);
 						// Format: Longitude, Latitude, Altitude
-						$lng = $coordinatesSplit[0];
-						$lat = $coordinatesSplit[1];
+						$lng = $coordinates_split[0];
+						$lat = $coordinates_split[1];
 						
 						return array($lng, $lat);
 						
 					}
-					else if (strcmp($status, "620") == 0)
+					elseif (strcmp($status, '620') == 0)
 					{
 						// sent geocodes too fast
 						$delay += 100000;
@@ -91,7 +90,7 @@ class Geocoder_Core {
 	 */
 	function geocode_feed ($feed_url = NULL)
 	{
-		$base_url = "http://" . GEOCODER_GEONAMES . "/rssToGeoRSS?";
+		$base_url = 'http://'.GEOCODER_GEONAMES.'/rssToGeoRSS?';
 		
 		if ($feed_url)
 		{
@@ -100,15 +99,14 @@ class Geocoder_Core {
 
 			if ($geonames_status == "200")
 			{ // Successful
-				$request_url = $base_url . "&feedUrl=" . urlencode($feed_url);
+				$request_url = $base_url.'&feedUrl='.urlencode($feed_url);
 			}
 			else
 			{ // Down perhaps?? Use direct feed
 				$request_url = $feed_url;
 			}
-			
-			$georss = file_get_contents($request_url);
-			//$georss = utf8_encode($georss);
+
+			$georss = (string) remote::get($request_url);
 
 			return $georss;
 			


### PR DESCRIPTION
http://dev.ushahidi.com/issues/show/415
http://dev.ushahidi.com/issues/show/1294

Additionally,
- Some people can't modify their php.ini to set allow_url_fopen
- Some people consider file_get_contents a security issue
- fsockopen/fread is (slightly) faster than file_get_contents
- "remote::get" has fewer characters than "file_get_contents"!
