### PR TITLE
Show hidden categories for admin's

### DIFF
--- a/application/controllers/admin/reports.php
+++ b/application/controllers/admin/reports.php
@@ -375,7 +375,7 @@ class Reports_Controller extends Admin_Controller {
 		$this->template->content->locale_array = Kohana::config('locale.all_languages');
 
 		// Create Categories
-		$this->template->content->categories = Category_Model::get_categories();
+		$this->template->content->categories = Category_Model::get_categories(0, TRUE, FALSE);
 		$this->template->content->new_categories_form = $this->_new_categories_form_arr();
 
 		// Time formatting

--- a/application/models/category.php
+++ b/application/models/category.php
@@ -119,7 +119,7 @@ class Category_Model extends ORM_Tree {
 	 * @param int $parent_id
 	 * @return ORM_Iterator
 	 */
-	public static function get_categories($parent_id = 0, $exclude_trusted = TRUE)
+	public static function get_categories($parent_id = 0, $exclude_trusted = TRUE, $exclude_hidden = TRUE)
 	{
 		// Check if the specified parent is valid
 		$where = (intval($parent_id) > 0 AND self::is_valid_category($parent_id))
@@ -127,7 +127,9 @@ class Category_Model extends ORM_Tree {
 			: array('parent_id' => 0);
 			
 		// Make sure the category is visible
-		$where = array_merge($where, array('category_visible' =>'1'));
+		if ($exclude_hidden) {
+			$where = array_merge($where, array('category_visible' =>'1'));
+		}
 		
 		// Exclude trusted reports
 		if ($exclude_trusted)


### PR DESCRIPTION
This uses to work (Originally implemented by https://github.com/ushahidi/Ushahidi_Web/pull/127) but seems to have broken at some point when the logic for getting categories was moved in to the Categories model.

The commit allow admins to select hidden categories when creating reports in the backend.
