### PR TITLE
Redirect members / admin to the appropriate dashboard on login

### DIFF
--- a/application/controllers/admin.php
+++ b/application/controllers/admin.php
@@ -83,10 +83,13 @@ class Admin_Controller extends Template_Controller
 		$this->session = Session::instance();
 		$this->auth->auto_login();
 
-		// Admin is not logged in, or this is a member (not admin)
-		if ( ! $this->auth->logged_in('login') OR $this->auth->logged_in('member'))
+		// Admin is not logged in
+		if ( ! $this->auth->logged_in('login') )
 		{
 			url::redirect('login');
+		// or this is a member (not admin)
+		} else if ( $this->auth->logged_in('member') ) {
+			url::redirect('members');
 		}
 
 		// Set Table Prefix

--- a/application/controllers/members.php
+++ b/application/controllers/members.php
@@ -51,9 +51,13 @@ class Members_Controller extends Template_Controller
 		$this->session = Session::instance();
 		$this->auth->auto_login();
 		
-		if ( ! $this->auth->logged_in('login') OR ! $this->auth->logged_in('member'))
+		// User not logged in send to members/login
+		if ( ! $this->auth->logged_in('login') )
 		{
 			url::redirect('members/login');
+		// or not a member try sending to admin
+		} elseif ( ! $this->auth->logged_in('member') ) {
+			url::redirect('admin');
 		}
 
 		// Set Table Prefix


### PR DESCRIPTION
Currently if you log in through members/login but with an admin role you get logged in but directed back to the log page. The same thing happens for members trying to log in via /admin.
This causes much confusion and users thinking they can't log in.

This patch redirects admin's to the admin dashboard and members to the member dashboard.
