### PR TITLE
Fix 'mailbox is empty' errors from the Email scheduler and imap module

### DIFF
--- a/application/libraries/Imap.php
+++ b/application/libraries/Imap.php
@@ -207,6 +207,8 @@ class Imap_Core {
 	 */
 	public function close()
 	{
+		// Dump imap errors to avoid 'Mailbox is empty' errors 
+		$error = imap_errors();
 		@imap_close($this->imap_stream);
 	}
 


### PR DESCRIPTION
When the email scheduler runs you sometimes get this error:
ERROR: Unknown: Mailbox is empty (errflg=1)

It's due to a bug in the PHP Imap module but this is a workaround - mainly so we can generate clean cron logs
