### PR TITLE
Divide by zero scheduler exception fix. 

### DIFF
--- a/application/libraries/Distance.php
+++ b/application/libraries/Distance.php
@@ -47,7 +47,11 @@ class Distance_Core
 			// Safety check
 			if ($dist > 0)
 			{
-				$dist = $EARTH_RADIUS_MILES * (-1 * atan($dist / sqrt(1 - $dist * $dist)) + M_PI / 2);
+				$sqrt = sqrt(1 - $dist * $dist);
+				if($sqrt > 0)
+				{
+					$dist = $EARTH_RADIUS_MILES * (-1 * atan($dist / $sqrt) + M_PI / 2);
+				}
 			}
 		}
 		


### PR DESCRIPTION
If $dist is exactly 1, the scheduler may experience a divide by zero
exception during distance calculations.
