### PR TITLE
256 Event::replace does not allow class overriding

### DIFF
--- a/system/core/Event.php
+++ b/system/core/Event.php
@@ -130,7 +130,7 @@ final class Event {
 	 */
 	public static function replace($name, $existing, $callback)
 	{
-		if (empty(self::$events[$name]) OR ($key = array_search($existing, self::$events[$name], TRUE)) === FALSE)
+		if (empty(self::$events[$name]) OR ($key = array_search($existing, self::$events[$name])) === FALSE)
 			return FALSE;
 
 		if ( ! in_array($callback, self::$events[$name], TRUE))


### PR DESCRIPTION
This allows for comparisons of classes that are not the same object
