### PR TITLE
PHP warning with no media

### DIFF
--- a/application/controllers/media.php
+++ b/application/controllers/media.php
@@ -87,7 +87,9 @@ class Media_Controller extends Controller {
         header('Content-type: '.$mime);
         header('Cache-Control: must-revalidate');
         header('Expires: '.gmdate("D, d M Y H:i:s", time() + $expiry_time).' GMT');
-        header('ETag: '.$mtime);
+        if ($file) {
+          header('ETag: '.$mtime);
+        }
         header("Last-Modified: ".gmdate("D, d M Y H:i:s", $mtime)." GMT");
 
         $oldetag = isset($_SERVER['HTTP_IF_NONE_MATCH'])?trim($_SERVER['HTTP_IF_NONE_MATCH']):'';


### PR DESCRIPTION
if $file does not exist a PHP warning is issued because $mtime is not
set.
