### PR TITLE
Fixed admin form to work with non-ASCII characters (updated)

### DIFF
--- a/application/controllers/admin/manage/forms.php
+++ b/application/controllers/admin/manage/forms.php
@@ -978,7 +978,7 @@ class Forms_Controller extends Admin_Controller {
 		$html .="        	$('#formadd_".$form_id."').hide(300);";
 		$html .="        	$('#form_fields_".$form_id."').hide();";
 		$html .="        	$('#form_fields_current_".$form_id."').html('');";
-		$html .="        	$('#form_fields_current_".$form_id."').html(unescape(data.response));";
+		$html .="        	$('#form_fields_current_".$form_id."').html(decodeURIComponent(data.response));";
 		$html .="        	$('#form_fields_current_".$form_id."').effect(\"highlight\", {}, 2000);";
 		$html .="        };";
 		$html .="    } ";

--- a/application/views/admin/categories_js.php
+++ b/application/views/admin/categories_js.php
@@ -48,15 +48,15 @@ $(document).ready(function() {
 function fillFields(id, parent_id, category_title, category_description, category_color, locale<?php foreach($locale_array as $lang_key => $lang_name) echo ', '.$lang_key; ?>)
 {
 	show_addedit();
-	$("#category_id").attr("value", unescape(id));
-	$("#parent_id").attr("value", unescape(parent_id));
-	$("#category_title").attr("value", unescape(category_title));
-	$("#category_description").attr("value", unescape(category_description));
-	$("#category_color").attr("value", unescape(category_color));
-	$("#locale").attr("value", unescape(locale));
+	$("#category_id").attr("value", decodeURIComponent(id));
+	$("#parent_id").attr("value", decodeURIComponent(parent_id));
+	$("#category_title").attr("value", decodeURIComponent(category_title));
+	$("#category_description").attr("value", decodeURIComponent(category_description));
+	$("#category_color").attr("value", decodeURIComponent(category_color));
+	$("#locale").attr("value", decodeURIComponent(locale));
 	<?php
 		foreach($locale_array as $lang_key => $lang_name) {
-			echo '$("#category_title_'.$lang_key.'").attr("value", unescape('.$lang_key.'));'."\n";
+			echo '$("#category_title_'.$lang_key.'").attr("value", decodeURIComponent('.$lang_key.'));'."\n";
 		}
 	?>
 }

--- a/application/views/admin/feeds_items_js.php
+++ b/application/views/admin/feeds_items_js.php
@@ -23,7 +23,7 @@ function preview ( id ){
 // Categories JS
 function fillFields(id )
 {
-	$("#feed_id").attr("value", unescape(id));
+	$("#feed_id").attr("value", decodeURIComponent(id));
 	
 }
 

--- a/application/views/admin/feeds_js.php
+++ b/application/views/admin/feeds_js.php
@@ -17,10 +17,10 @@
 function fillFields(id, feed_name, feed_url,
  feed_visible )
 {
-	$("#feed_id").attr("value", unescape(id));
-	$("#feed_name").attr("value", unescape(feed_name));
-	$("#feed_url").attr("value", unescape(feed_url));
-	$("#feed_visible").attr("value", unescape(feed_visible));
+	$("#feed_id").attr("value", decodeURIComponent(id));
+	$("#feed_name").attr("value", decodeURIComponent(feed_name));
+	$("#feed_url").attr("value", decodeURIComponent(feed_url));
+	$("#feed_visible").attr("value", decodeURIComponent(feed_visible));
 	
 }
 

--- a/application/views/admin/forms_js.php
+++ b/application/views/admin/forms_js.php
@@ -27,10 +27,10 @@ function fillFields(id, form_title, form_description,
  form_visible )
 {
 	show_addedit();
-	$("#form_id").attr("value", unescape(id));
-	$("#form_title").attr("value", unescape(form_title));
-	$("#form_description").attr("value", unescape(form_description));
-	$("#form_active").attr("value", unescape(form_active));
+	$("#form_id").attr("value", decodeURIComponent(id));
+	$("#form_title").attr("value", decodeURIComponent(form_title));
+	$("#form_description").attr("value", decodeURIComponent(form_description));
+	$("#form_active").attr("value", decodeURIComponent(form_active));
 	
 }
 
@@ -114,7 +114,7 @@ function fieldAction( action, confirmAction, field_id, form_id, field_type )
 				function(data){
 					if (data.status == 'success'){
 						$('#form_fields_current_' + form_id).html('');
-						$('#form_fields_current_' + form_id).html(unescape(data.response));
+						$('#form_fields_current_' + form_id).html(decodeURIComponent(data.response));
 						//$('#form_fields_current_' + form_id).effect("highlight", {}, 2000);
 						$('#form_fields_current_' + form_id).css({
 						"background-image" : "none"
@@ -128,7 +128,7 @@ function fieldAction( action, confirmAction, field_id, form_id, field_type )
 			function(data){
 				if (data.status == 'success'){
 					$('#form_fields_current_' + form_id).html('');
-					$('#form_fields_current_' + form_id).html(unescape(data.response));
+					$('#form_fields_current_' + form_id).html(decodeURIComponent(data.response));
 					//$('#form_fields_current_' + form_id).effect("highlight", {}, 2000);
 					$('#form_fields_current_' + form_id).css({
 					"background-image" : "none"
@@ -141,7 +141,7 @@ function fieldAction( action, confirmAction, field_id, form_id, field_type )
 			function(data){
 				if (data.status == 'success'){
 					$('#form_fields_current_' + form_id).html('');
-					$('#form_fields_current_' + form_id).html(unescape(data.response));
+					$('#form_fields_current_' + form_id).html(decodeURIComponent(data.response));
 					//$('#form_fields_current_' + form_id).effect("highlight", {}, 2000);
 					$('#form_fields_current_' + form_id).css({
 					"background-image" : "none"

--- a/application/views/admin/layers_js.php
+++ b/application/views/admin/layers_js.php
@@ -18,11 +18,11 @@
 // Layers JS
 function fillFields(id, layer_name, layer_url, layer_color, layer_file_old)
 {
-	$("#layer_id").attr("value", unescape(id));
-	$("#layer_name").attr("value", unescape(layer_name));
-	$("#layer_url").attr("value", unescape(layer_url));
-	$("#layer_color").attr("value", unescape(layer_color));
-	$("#layer_file_old").attr("value", unescape(layer_file_old));
+	$("#layer_id").attr("value", decodeURIComponent(id));
+	$("#layer_name").attr("value", decodeURIComponent(layer_name));
+	$("#layer_url").attr("value", decodeURIComponent(layer_url));
+	$("#layer_color").attr("value", decodeURIComponent(layer_color));
+	$("#layer_file_old").attr("value", decodeURIComponent(layer_file_old));
 }
 
 function layerAction ( action, confirmAction, id )

--- a/application/views/admin/levels.php
+++ b/application/views/admin/levels.php
@@ -143,9 +143,9 @@
 			// Levels JS
 			function fillFields(id, level_title, level_description, level_weight)
 			{
-				$("#level_id").attr("value", unescape(id));
-				$("#level_title").attr("value", unescape(level_title));
-				$("#level_description").attr("value", unescape(level_description));
-				$("#level_weight").attr("value", unescape(level_weight));
+				$("#level_id").attr("value", decodeURIComponent(id));
+				$("#level_title").attr("value", decodeURIComponent(level_title));
+				$("#level_description").attr("value", decodeURIComponent(level_description));
+				$("#level_weight").attr("value", decodeURIComponent(level_weight));
 			}
 			</script>

--- a/application/views/admin/pages_js.php
+++ b/application/views/admin/pages_js.php
@@ -21,13 +21,13 @@
 function fillFields(id, page_title, page_tab,
  page_description )
 {
-	$("#page_id").attr("value", unescape(id));
+	$("#page_id").attr("value", decodeURIComponent(id));
 	page_title = decodeURIComponent(escape($.base64.decode(page_title)));
-	$("#page_title").attr("value", unescape(page_title));
+	$("#page_title").attr("value", decodeURIComponent(page_title));
 	page_tab = decodeURIComponent(escape($.base64.decode(page_tab)));
-	$("#page_tab").attr("value", unescape(page_tab));
+	$("#page_tab").attr("value", decodeURIComponent(page_tab));
 	page_description = decodeURIComponent(escape($.base64.decode(page_description)));
-	$("#page_description").attr("value", unescape(page_description));
+	$("#page_description").attr("value", decodeURIComponent(page_description));
 	hb_full.set_text(unescape(page_description));
 }
 

--- a/application/views/admin/reporters_js.php
+++ b/application/views/admin/reporters_js.php
@@ -32,16 +32,16 @@ function fillFields(id, level_id, service_name, service_account, location_id, lo
 {
 	show_addedit();
 	$('#add_edit_form').show();
-	$("#reporter_id").attr("value", unescape(id));
-	$("#level_id").attr("value", unescape(level_id));
-	$("#service_name").attr("value", unescape(service_name));
-	$("#reporter_service").text(unescape(service_name));
-	$("#service_account").attr("value", unescape(service_account));
-	$("#reporter_account").text(unescape(service_account));
-	$("#location_id").attr("value", unescape(location_id));
-	$("#location_name").attr("value", unescape(location_name));
-	$("#latitude").attr("value", unescape(latitude));
-	$("#longitude").attr("value", unescape(longitude));
+	$("#reporter_id").attr("value", decodeURIComponent(id));
+	$("#level_id").attr("value", decodeURIComponent(level_id));
+	$("#service_name").attr("value", decodeURIComponent(service_name));
+	$("#reporter_service").text(decodeURIComponent(service_name));
+	$("#service_account").attr("value", decodeURIComponent(service_account));
+	$("#reporter_account").text(decodeURIComponent(service_account));
+	$("#location_id").attr("value", decodeURIComponent(location_id));
+	$("#location_name").attr("value", decodeURIComponent(location_name));
+	$("#latitude").attr("value", decodeURIComponent(latitude));
+	$("#longitude").attr("value", decodeURIComponent(longitude));
 	showMap();
 }
 

--- a/application/views/admin/scheduler_js.php
+++ b/application/views/admin/scheduler_js.php
@@ -2,12 +2,12 @@ function fillFields(id, scheduler_name, scheduler_weekday,
 	scheduler_day, scheduler_hour, scheduler_minute)
 {
 	$('#add_edit_form').show();
-	$("#scheduler_id").attr("value", unescape(id));
-	$("#scheduler_name").attr("value", unescape(scheduler_name));
-	$("#scheduler_weekday").attr("value", unescape(scheduler_weekday));
-	$("#scheduler_day").attr("value", unescape(scheduler_day));
-	$("#scheduler_hour").attr("value", unescape(scheduler_hour));
-	$("#scheduler_minute").attr("value", unescape(scheduler_minute));
+	$("#scheduler_id").attr("value", decodeURIComponent(id));
+	$("#scheduler_name").attr("value", decodeURIComponent(scheduler_name));
+	$("#scheduler_weekday").attr("value", decodeURIComponent(scheduler_weekday));
+	$("#scheduler_day").attr("value", decodeURIComponent(scheduler_day));
+	$("#scheduler_hour").attr("value", decodeURIComponent(scheduler_hour));
+	$("#scheduler_minute").attr("value", decodeURIComponent(scheduler_minute));
 }
 
 

--- a/application/views/admin/sharing_js.php
+++ b/application/views/admin/sharing_js.php
@@ -18,10 +18,10 @@
 // Sharing JS
 function fillFields(id, sharing_url, sharing_name, sharing_color)
 {
-	$("#sharing_id").attr("value", unescape(id));
-	$("#sharing_name").attr("value", unescape(sharing_name));
-	$("#sharing_url").attr("value", unescape(sharing_url));
-	$("#sharing_color").attr("value", unescape(sharing_color));
+	$("#sharing_id").attr("value", decodeURIComponent(id));
+	$("#sharing_name").attr("value", decodeURIComponent(sharing_name));
+	$("#sharing_url").attr("value", decodeURIComponent(sharing_url));
+	$("#sharing_color").attr("value", decodeURIComponent(sharing_color));
 }
 
 // Ajax Submission

--- a/application/views/admin/users_js.php
+++ b/application/views/admin/users_js.php
@@ -16,11 +16,11 @@
 		// Users JS
 		function fillFields(id, username, name, role, email)
 		{
-			$("#user_id").attr("value", unescape(id));
-			$("#username").attr("value", unescape(username));
-			$("#name").attr("value", unescape(name));
-			$('#role').attr("value",unescape( role ) );
-			$('#email').attr("value",unescape( email ) );
+			$("#user_id").attr("value", decodeURIComponent(id));
+			$("#username").attr("value", decodeURIComponent(username));
+			$("#name").attr("value", decodeURIComponent(name));
+			$('#role').attr("value", decodeURIComponent( role ) );
+			$('#email').attr("value", decodeURIComponent( email ) );
 			
 		}
 		

--- a/application/views/admin/users_roles_js.php
+++ b/application/views/admin/users_roles_js.php
@@ -1,23 +1,23 @@
 function fillFields(id, name, description, access_level, reports_view, reports_edit, reports_evaluation, reports_comments, reports_download, reports_upload, messages, messages_reporters, stats, settings, manage, users)
 {
 	show_addedit();
-	$("#role_id").attr("value", unescape(id));
-	$("#name").attr("value", unescape(name));
-	$("#description").attr("value", unescape(description));
-	$("#access_level").attr("value", unescape(access_level));
+	$("#role_id").attr("value", decodeURIComponent(id));
+	$("#name").attr("value", decodeURIComponent(name));
+	$("#description").attr("value", decodeURIComponent(description));
+	$("#access_level").attr("value", decodeURIComponent(access_level));
 
-	$("#reports_view").attr("checked", B(unescape(reports_view)));
-	$("#reports_edit").attr("checked", B(unescape(reports_edit)));
-	$("#reports_evaluation").attr("checked", B(unescape(reports_evaluation)));
-	$("#reports_comments").attr("checked", B(unescape(reports_comments)));
-	$("#reports_download").attr("checked", B(unescape(reports_download)));
-	$("#reports_upload").attr("checked", B(unescape(reports_upload)));
-	$("#messages").attr("checked", B(unescape(messages)));
-	$("#messages_reporters").attr("checked", B(unescape(messages_reporters)));
-	$("#stats").attr("checked", B(unescape(stats)));
-	$("#settings").attr("checked", B(unescape(settings)));
-	$("#manage").attr("checked", B(unescape(manage)));
-	$("#users").attr("checked", B(unescape(users)));
+	$("#reports_view").attr("checked", B(decodeURIComponent(reports_view)));
+	$("#reports_edit").attr("checked", B(decodeURIComponent(reports_edit)));
+	$("#reports_evaluation").attr("checked", B(decodeURIComponent(reports_evaluation)));
+	$("#reports_comments").attr("checked", B(decodeURIComponent(reports_comments)));
+	$("#reports_download").attr("checked", B(decodeURIComponent(reports_download)));
+	$("#reports_upload").attr("checked", B(decodeURIComponent(reports_upload)));
+	$("#messages").attr("checked", B(decodeURIComponent(messages)));
+	$("#messages_reporters").attr("checked", B(decodeURIComponent(messages_reporters)));
+	$("#stats").attr("checked", B(decodeURIComponent(stats)));
+	$("#settings").attr("checked", B(decodeURIComponent(settings)));
+	$("#manage").attr("checked", B(decodeURIComponent(manage)));
+	$("#users").attr("checked", B(decodeURIComponent(users)));
 }
 
 // Ajax Submission

--- a/application/views/reports_submit_edit_js.php
+++ b/application/views/reports_submit_edit_js.php
@@ -679,7 +679,7 @@
 					function(data){
 						if (data.status == 'success'){
 							$('#custom_forms').html('');
-							$('#custom_forms').html(unescape(data.response));
+							$('#custom_forms').html(decodeURIComponent(data.response));
 							$('#form_loader').html('');
 						}
 				  	}, "json");

--- a/application/views/reset_password_js.php
+++ b/application/views/reset_password_js.php
@@ -16,7 +16,7 @@
 
 	function fillFields(email)
 	{
-		$('#email').attr("value",unescape( email ) );
+		$('#email').attr("value", decodeURIComponent( email ) );
 			
 	}
 


### PR DESCRIPTION
This fix is needed to support Arabic, Hebrew, Russian etc, anything other than the Latin charset.

The function `encode` does not support UTF-8 as per conversation at https://github.com/ushahidi/Ushahidi_Web/pull/134

I confirmed this fixes #262 (Hebrew) and #214 (Russian). 

Broken screenshot: http://imgur.com/s5Bxn,FaUl7#1
Fixed screenshot: http://imgur.com/s5Bxn,FaUl7#0

This is a reformulation of an old pull request by matsuu, (which got old enough that it no longer applies cleanly). I used the same basic strategy of replacing unencode wherever I could find it.  NOTE: I did not include the base64 stuff in his patch — I hope this makes this easier to apply.
