### PR TITLE
SQL file out of sync during install

### DIFF
--- a/sql/ushahidi.sql
+++ b/sql/ushahidi.sql
@@ -337,7 +337,7 @@ INSERT INTO `country` (`id`, `iso`, `country`, `capital`, `cities`) VALUES
 *
 */
 
-CREATE TABLE `externalapp` (
+CREATE TABLE IF NOT EXISTS `externalapp` (
 `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
 `name` VARCHAR( 255 ) NOT NULL ,
 `url` VARCHAR( 255 ) NOT NULL


### PR DESCRIPTION
I got an error during installation. The ushahidi.sql file needs to have "IF NOT EXISTS" when creating the externalapp table. This only happens if table prefixes are used during the install process. 
