### PR TITLE
mo=1 is a required paramter for API now

### DIFF
--- a/plugins/clickatell/libraries/Clickatell_API.php
+++ b/plugins/clickatell/libraries/Clickatell_API.php
@@ -204,7 +204,7 @@ class Clickatell_API_Core {
         $to = str_replace($cleanup_chr, "", $to);
 
     	/* Send SMS now */
-    	$comm = sprintf ("%s/sendmsg?session_id=%s&to=%s&from=%s&text=%s&callback=%s&unicode=%s%s",
+    	$comm = sprintf ("%s/sendmsg?session_id=%s&to=%s&from=%s&text=%s&callback=%s&unicode=%s%s&mo=1",
             $this->base,
             $this->session,
             rawurlencode($to),


### PR DESCRIPTION
This fix is also referenced in in the [patch](https://github.com/nexleaf/Ushahidi_Web/commit/c5e3b792c47b94d53658f4c669a6b22a56728cc9.diff) from #229
