### PR TITLE
Replace password validation with alpha_dash

### DIFF
--- a/application/controllers/login.php
+++ b/application/controllers/login.php
@@ -201,7 +201,7 @@ class Login_Controller extends Template_Controller {
 			//	Add some filters
 			$post->pre_filter('trim', TRUE);
 
-			$post->add_rules('password','required', 'length['.kohana::config('auth.password_length').']','alpha_numeric');
+			$post->add_rules('password','required', 'length['.kohana::config('auth.password_length').']','alpha_dash');
 			$post->add_rules('name','required','length[3,100]');
 			$post->add_rules('email','required','email','length[4,64]');
 			$post->add_callbacks('username', array($this,'username_exists_chk'));
@@ -211,7 +211,7 @@ class Login_Controller extends Template_Controller {
 			if (!empty($post->password))
 			{
 				$post->add_rules('password','required','length['.kohana::config('auth.password_length').']'
-					,'alpha_numeric','matches[password_again]');
+					,'alpha_dash','matches[password_again]');
 			}
 
 			if ($post->validate())


### PR DESCRIPTION
There is an issue where new accounts, if they did not have a valid
password, alpha_numeric currently, the error message they recieve
on /login if the browser was set to en_US is alpha_numeric.  There was
no alpha_numeric entry in the il8n file, but there was one for
alpha_dash so I replaced this with that so at least they get the right
error message.  Looking at this however I still notice that the default
user password validation is not very secure.  Idealy the default password
validation mechanisim should be very strong with the option of allowing
users to decrease the password strength in application/config/auth.php
