### PR TITLE
removed the category filter when querying objects via the bounds

### DIFF
--- a/application/libraries/api/Api_Object.php
+++ b/application/libraries/api/Api_Object.php
@@ -454,18 +454,6 @@ abstract class Api_Object_Core {
 
 		return $this->id;
     }
-       protected function check_cordinate_value($cord)
-       {
-            if(is_numeric($cord))
-            {
-               $this->cord = $cord;
-            } else 
-            {
-               $this->cord = Null;
-            }
-            return $this->cord;
-       }
-
     
 }
 

--- a/application/libraries/api/MY_Incidents_Api_Object.php
+++ b/application/libraries/api/MY_Incidents_Api_Object.php
@@ -102,7 +102,7 @@ class Incidents_Api_Object extends Api_Object_Core {
                                                 'l.latitude = '.$this->request['latitude'],
                                                 'l.longitude = '.$this->request['longitude']
                                    );
-                                   if (is_null($lat) or is_null($lon))
+                                   if ($lat==0 or $lon==0)
                                    {
                                       $this->set_error_message(array(
                                                 "error" => $this->api_service->get_error_msg(001, 'invalid latitude or longitude values')
@@ -919,15 +919,7 @@ class Incidents_Api_Object extends Api_Object_Core {
 	}
        protected function check_cordinate_value($cord)
        {
-            if(is_numeric($cord))
-            {
-               $this->cord = floatval($cord);
-            } 
-            else 
-            {
-               $this->cord = Null;
-            }
-            return $this->cord;
+            return floatval($cord);
        }
 
 }


### PR DESCRIPTION
This is to enable us to pull out the incidents via the api, by passing the bounds.
