### PR TITLE
Better handling of SelectControl in ushahidi.js

### DIFF
--- a/themes/default/views/main/main_js.php
+++ b/themes/default/views/main/main_js.php
@@ -210,7 +210,7 @@ jQuery(function() {
 		name: "<?php echo Kohana::lang('ui_main.reports'); ?>",
 		url: reportsURL,
 		transform: false
-	}, true);
+	}, true, true);
 
 
 	// Register the referesh timeline function as a callback
@@ -347,7 +347,7 @@ jQuery(function() {
 				features: layerFeatures,
 				styleMap: checkinStyleMap,
 				transform: true,
-			});
+			}, false, true);
 		}
 	});
 


### PR DESCRIPTION
This solves long standing issues with multiple layers on a map not being clickable at the same time. In particular this closes #780 and avoids having to make any backend changes are the sharing plugin.

Ushahidi.js now uses just one select control, and adds additional layers to the control as they're loaded. This enables all layers to be clickable at once. This should cover reports, sharing, kml and checkin layers as they're all Vector layers.
