### PR TITLE
Report total rating for an incident rather than one rating arbitrarily.

### DIFF
--- a/application/controllers/reports.php
+++ b/application/controllers/reports.php
@@ -617,14 +617,7 @@ class Reports_Controller extends Main_Controller {
 			$this->template->content->incident_category = $incident->incident_category;
 
 			// Incident rating
-			$rating = ORM::factory('rating')
-					->join('incident','incident.id','rating.incident_id','INNER')
-					->where('rating.incident_id',$incident->id)
-					->find();
-					
-			$this->template->content->incident_rating = ($rating->rating == '')
-				? 0
-				: $rating->rating;
+			$this->template->content->incident_rating = $this->_get_rating($incident->id, 'original');
 
 			// Retrieve Media
 			$incident_news = array();


### PR DESCRIPTION
Hi there,

When fetching the incident rating for reports, Ushahidi currently does this:

``` php
$rating = ORM::factory('rating')
    ->join('incident','incident.id','rating.incident_id','INNER')
    ->where('rating.incident_id',$incident->id)
    ->find();
```

... which is just arbitrarily fetching one rating from all the possible ratings for that incident. This means that the report will only ever return a rating of -1, 0 or 1 (regardless of how many people have rated it!), and that too inconsistently depending on which row the ORM returns.

I think the sum of all ratings for any incident is what should be used here? There is already a helper function to fetch this.
