### PR TITLE
Typo in variable name in Api_Object

### DIFF
--- a/application/libraries/api/Api_Object.php
+++ b/application/libraries/api/Api_Object.php
@@ -24,7 +24,7 @@ abstract class Api_Object_Core {
 	 * Prefix for the database tables
 	 * @var string
 	 */
-	protected $table_preix;
+	protected $table_prefix;
 	
 	/**
 	 * Form validation error messages


### PR DESCRIPTION
Protected `$table_preix` should be `$table_prefix`.
