### PR TITLE
FrontlineSMS plugin admin view updated for FLSMS v2.2 support

### DIFF
--- a/plugins/frontlinesms/views/frontlinesms/admin/frontlinesms_settings.php
+++ b/plugins/frontlinesms/views/frontlinesms/admin/frontlinesms_settings.php
@@ -4,11 +4,11 @@
 			<span class="big_blue_span"><?php echo Kohana::lang('ui_main.step');?> 1:</span>
 		</td>
 		<td>
-			<h4 class="fix"><a href="#" class="tooltip" title="<?php echo Kohana::lang("tooltips.settings_flsms_download"); ?>"><?php echo Kohana::lang('settings.sms.flsms_download');?></a></h4>
+			<h4 class="fix"><?php echo Kohana::lang('settings.sms.flsms_download');?></h4>
 			<p>
-				<?php echo Kohana::lang('settings.sms.flsms_description');?>.
+				<?php echo Kohana::lang('settings.sms.flsms_description');?>
 			</p>
-			<a href="http://www.frontlinesms.com/the-software/frontlinesms-version-1/" class="no_border">
+			<a href="http://www.frontlinesms.com/the-software/download/" class="no_border">
 				<img src="<?php echo url::base() ?>media/img/admin/download_frontline_engine.gif" />
 			</a>
 		</td>
@@ -18,13 +18,13 @@
 			<span class="big_blue_span"><?php echo Kohana::lang('ui_main.step');?> 2:</span>
 		</td>
 		<td>
-			<h4 class="fix"><a href="#" class="tooltip" title="<?php echo Kohana::lang("tooltips.settings_flsms_synchronize"); ?>"><?php echo Kohana::lang('settings.sms.flsms_synchronize');?></a></h4>
+			<h4 class="fix"><?php echo Kohana::lang('settings.sms.flsms_synchronize');?></h4>
 			<p>
-				<?php echo Kohana::lang('settings.sms.flsms_instructions');?>.
+				<?php echo Kohana::lang('settings.sms.flsms_instructions');?>
 			</p>
 			<p class="sync_key">
-				<?php echo Kohana::lang('settings.sms.flsms_key');?>: <span><?php echo $frontlinesms_key; ?></span><br /><br />
-				<?php echo Kohana::lang('settings.sms.flsms_link');?>:<br /><span><?php echo $frontlinesms_link; ?></span>
+				<?php echo Kohana::lang('settings.sms.flsms_link');?>:<br /><span><?php echo $frontlinesms_link; ?></span><br /><br />
+				<?php echo Kohana::lang('settings.sms.flsms_key');?>:<br /><span><?php echo $frontlinesms_key; ?></span>
 			</p>
 		</td>
 	</tr>	


### PR DESCRIPTION
Very slight changes to the admin view of the FLSMS plugin to support updated instructions for v2.2, not v1.6.  Fixed some links.
