### PR TITLE
Fix custom form fields validation #671

### DIFF
--- a/application/helpers/reports.php
+++ b/application/helpers/reports.php
@@ -145,19 +145,9 @@ class reports_Core {
 		$post->add_rules('incident_active', 'between[0,1]');
 		$post->add_rules('incident_verified', 'between[0,1]');
 		$post->add_rules('incident_zoom', 'numeric');
-		
+
 		// Custom form fields validation
-		$errors = customforms::validate_custom_form_fields($post);
-
-		// Check if any errors have been returned
-		if (count($errors) > 0)
-		{
-			foreach ($errors as $field_name => $error)
-			{
-				$post->add_error($field_name, $error);
-			}
-		}
-
+		customforms::validate_custom_form_fields($post);
 		//> END custom form fields validation
 
 		// Return

--- a/tests/phpunit/classes/helpers/Customforms_Test.php
+++ b/tests/phpunit/classes/helpers/Customforms_Test.php
@@ -128,7 +128,9 @@ class Customforms_Helper_Test extends PHPUnit_Framework_TestCase {
 							->pre_filter('trim', TRUE);
 
 		// Get the return value for validation of valid date
-		$errors = customforms::validate_custom_form_fields($valid_validator);
+		customforms::validate_custom_form_fields($valid_validator);
+
+		$errors = $valid_validator->errors();
 
 		// Assert that validation of the valid data returns no errors
 		$this->assertEquals(0, count($errors), "Some errors have been found".Kohana::debug($errors));
@@ -139,6 +141,8 @@ class Customforms_Helper_Test extends PHPUnit_Framework_TestCase {
 
 		// Get the return value for validation of invalid data
 		$errors = customforms::validate_custom_form_fields($invalid_validator);
+
+		$errors = $invalid_validator->errors();
 
 		// Assert that the validation of the invalid data returns some errors
 		$this->assertEquals(TRUE, count($errors) > 0, "Expected to encounter errors. None found: ".count($errors));


### PR DESCRIPTION
Pulled in changes from @rjmackay.
- Actually return sane error messages
- Push errors directly into $post object
- Bind all error to 'custom_field' rather than trying to bind to
  individual fields as this didn't work and meant no errors were displayed
- Still a bit broken since only the last error will get displayed,
  not great if you have 10 errors and only see 1
- Fix unit test to grab the errors from the $post object
