### PR TITLE
Unable to create new users - database error - no default value for riverid

### DIFF
--- a/application/models/user.php
+++ b/application/models/user.php
@@ -40,14 +40,7 @@ class User_Model extends Auth_User_Model {
 			$user->name = $name;
 		}
 
-		if ($riverid != false)
-		{
-			$user->riverid = $riverid;
-		}
-		else
-		{
-			$user->riverid = '';
-		}
+		$user->riverid = ( $riverid == false ) ? '' : $riverid;
 
 		// Add New Roles if:
 		//    1. We don't require admin to approve users (will be added when admin approves)


### PR DESCRIPTION
On a clean install of Ushahidi, I tried to create an account from `/ushahidi/login`. The following error is thrown:

```
Database error: Field 'riverid' doesn't have a default value - 
INSERT INTO `users` (`email`, `username`, `password`, `name`) VALUES ('test@example.com', '281921918', 'a05534c598a1c092fb9ac86d2f0c8261b7d49fcc3d15c06f14', 'test')
```

Same thing happens when I try to create a user through the admin interface (`/ushahidi/admin/users/edit/`).

When riverid is disabled, the controller does not supply a value for `$user->riverid`, and the database does not have a default value, hence the fatal error.

Also note that the `username` value above is a large integer - I'm not sure why that is, but it also looks like a bug?
