### PR TITLE
Cannot enable clean URLs from admin, _check_for_clean_url() always returns false.

### DIFF
--- a/application/controllers/admin/settings.php
+++ b/application/controllers/admin/settings.php
@@ -1093,7 +1093,7 @@ class Settings_Controller extends Admin_Controller {
 
 	private function _check_for_clean_url() {
 
-		$url = url::base()."help";
+		$url = url::base().'reports/';
 
 		$curl_handle = curl_init();
 


### PR DESCRIPTION
If you disable clean URL's (or don't enable them during initial setup), it is not possible to re-enable them from Settings -> Clean URLs (the option is always disabled). This is because `Settings_Controller::_check_for_clean_url()` always returns false.

It tries to visit `ushahidi/help`, which always results in a 404. Looking at the default theme, there used to be a file at `views/help.php` but there isn't any more. So this needs to be changed to a URL that exists. In the patch I have used `ushahidi/reports/` as that is less likely to change (although it may be worth thinking about a more robust solution in the long term?).

Cheers,

Samir
