### PR TITLE
Default report time for web submissions is almost always wrong

### DIFF
--- a/application/controllers/reports.php
+++ b/application/controllers/reports.php
@@ -282,7 +282,7 @@ class Reports_Controller extends Main_Controller {
 
 		// Initialize Default Values
 		$form['incident_date'] = date("m/d/Y",time());
-		$form['incident_hour'] = date('g');
+		$form['incident_hour'] = date('h');
 		$form['incident_minute'] = date('i');
 		$form['incident_ampm'] = date('a');
 		$form['country_id'] = Kohana::config('settings.default_country');


### PR DESCRIPTION
The `$incident_hour` array used by the web report submission forms looks like this:

``` php
array (
  '01' => '01',
  '02' => '02',
  '03' => '03',
  '04' => '04',
  '05' => '05',
  '06' => '06',
  '07' => '07',
  '08' => '08',
  '09' => '09',
  10 => '10',
  11 => '11',
  12 => '12',
);
```

However, in application/controllers/reports.php, the default value for `$form['incident_hour']` is:

`$form['incident_hour'] = date('g');`  (12-hour format of an hour **without leading zeros**)

So the resulting value will not have a leading zero, and the form helper never finds a match when hour is less than 10, and always defaults to "01". Probably just a typo ;-).

This needs to be `date('h')` instead, like what is used in `application/controllers/admin/reports.php` and `application/controllers/members/reports.php`.
