### PR TITLE
Twitter "test settings" always reports an error

### DIFF
--- a/application/controllers/admin/settings/test_twitter.php
+++ b/application/controllers/admin/settings/test_twitter.php
@@ -36,8 +36,8 @@ class Test_Twitter_Controller extends Admin_Controller {
 
 		$connection = new Twitter_Oauth($consumer_key,$consumer_secret,$access_token['oauth_token'],$access_token['oauth_token_secret']);
 		$connection->decode_json = FALSE;
-		$verify_credentials = $connection->get('account/verify_credentials');
-		if ($verify_credentials['code'] == 200) 
+		$connection->get('account/verify_credentials');
+		if ($connection->http_code == 200) 
 		{
 			echo json_encode(array("status"=>"success", "message"=>Kohana::lang('ui_main.success')));
 		}


### PR DESCRIPTION
To reproduce: try hitting the "test settings" button on the Twitter settings page. It'll always report a credentials error.

The code in the twitter test controller seems to be expecting an array with a response code in the OAuth response, but that actually contains Twitter's JSON response (no status codes). It should be checking the response code on the OAuth object itself.
