### PR TITLE
Twitter scheduler bugs

### DIFF
--- a/application/controllers/scheduler/s_twitter.php
+++ b/application/controllers/scheduler/s_twitter.php
@@ -130,10 +130,10 @@ class S_Twitter_Controller extends Controller {
 				// Grab geo data if it exists from the tweet
 				$tweet_lat = null;
 				$tweet_lon = null;
-				if ($tweet->{'geo'} != null)
+				if ($tweet->{'coordinates'} != null)
 				{
-					$tweet_lat = $tweet->{'geo'}->coordinates[0];
-					$tweet_lon = $tweet->{'geo'}->coordinates[1];
+					$tweet_lat = $tweet->{'coordinates'}->coordinates[0];
+					$tweet_lon = $tweet->{'coordinates'}->coordinates[1];
 				}
 
 				// Save Tweet as Message


### PR DESCRIPTION
A few issues:
- Twitter scheduler does not set correct incident mode when generating reports from Twitter All reports get the default "web" mode when they should be getting "twitter".
- It is using a deprecated object (`geo`) from the Twitter API
- It is making a redundant `verify_credentials` query.
