### PR TITLE
Some stats page issues.

### DIFF
--- a/application/models/stats.php
+++ b/application/models/stats.php
@@ -518,6 +518,12 @@ STATSCOLLECTOR;
 		// Ignore errors since we are error checking later
 
 		$xml = simplexml_load_string(Stats_Model::_curl_req($stat_url));
+
+		if($xml == false)
+		{
+			return false;
+		}
+
 		$stat_id = (string) $xml->id[0];
 		$stat_key = (string) $xml->key[0];
 


### PR DESCRIPTION
- If there is a connection problem when trying to create a site on the
  stats server, a fatal error occurs.
- The stats tab shouldn't be visible if stats are disabled?
