### PR TITLE
HTML in comments is over-escaped 

### DIFF
--- a/themes/default/views/reports/comments.php
+++ b/themes/default/views/reports/comments.php
@@ -11,7 +11,7 @@
 				<strong><?php echo html::strip_tags($comment->comment_author); ?></strong>&nbsp;(<?php echo date('M j Y', strtotime($comment->comment_date)); ?>)
 			</div>
 
-			<div><?php echo html::escape($comment->comment_description); ?></div>
+			<div><?php echo html::clean($comment->comment_description); ?></div>
 
 		</div>
 	<?php endforeach; ?>


### PR DESCRIPTION
To reproduce, submit a comment with special characters. e.g.,

```
This comment has an ampersand & some comparison < operators >
```

Expected HTML output in view:

``` html
This comment has an ampersand &amp; some comparison &lt; operators &gt;
```

Actual output:

``` html
This comment has an ampersand &amp;amp; some comparison &amp;lt; operators &amp;gt;
```
