### PR TITLE
Upload images .jpeg fails - .jpg ok             #1136

### DIFF
--- a/application/helpers/reports.php
+++ b/application/helpers/reports.php
@@ -527,7 +527,8 @@ class reports_Core {
 			{
 				$new_filename = $incident->id.'_'.$i.'_'.time();
 
-				$file_type = substr($filename,-4);
+				//$file_type = substr($filename,-4);
+				$file_type =".".substr(strrchr($filename, '.'), 1); // replaces the commented line above to take care of images with .jpeg extension.
 				
 				// Name the files for the DB
 				$media_link = $new_filename.$file_type;


### PR DESCRIPTION
Image with .jpeg extensions were not uploaded successfully because the code snippet to get the extension was picking the last four characters of the filename which includes the dot[.] which was being missed for the case of the .jpeg which is five characters plus the dot.

The fix gets the file type using the last appearance of the dot on the filename thus works for all file types.
