### PR TITLE
Admin js fails because it conflicts with prototype.js

### DIFF
--- a/media/js/admin.js
+++ b/media/js/admin.js
@@ -1,21 +1,23 @@
-function info_search(){
-	$("#info-search").submit();
-}
-function show_addedit(toggle){
-	var addEditForm = $("#addedit");
-	if (toggle) {
-		addEditForm.toggle(400);
-	} else {
-		addEditForm.show(400);
-	}
-	// Clear fields, but not buttons or the CSRF token.
-	$(':input','#addedit')
-	 .not(':button, :submit, :reset, #action, :checkbox, [name="form_auth_token"]')
-	 .val('')
-	 .removeAttr('selected');
-	
-	// Reset checkbox separately to avoid wiping its value
-	$(':checkbox','#addedit').removeAttr('checked');
-		
-	$("a.add").focus();
-}
+(function($){
+    info_search = function(){
+        $("#info-search").submit();
+    }
+    show_addedit = function(toggle){
+        var addEditForm = $("#addedit");
+        if (toggle) {
+            addEditForm.toggle(400);
+        } else {
+            addEditForm.show(400);
+        }
+        // Clear fields, but not buttons or the CSRF token.
+        $(':input','#addedit')
+         .not(':button, :submit, :reset, #action, :checkbox, [name="form_auth_token"]')
+         .val('')
+         .removeAttr('selected');
+
+        // Reset checkbox separately to avoid wiping its value
+        $(':checkbox','#addedit').removeAttr('checked');
+
+        $("a.add").focus();
+    }
+})(jQuery);


### PR DESCRIPTION
The code in `admin.js` assumes that `$` is reserved for jQuery, which causes conflicts - for example on the admin dashboard where Prototype is loaded for the chart and takes over that variable. This means that the report search form doesn't work (`$("#info-search") is null`).
