### PR TITLE
added Web.config file to allow one to host their uhsahidi installation o...

### DIFF
--- a/Web.Config
+++ b/Web.Config
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<system.webServer>
+		<rewrite>
+			<rules>
+				<rule name="rule 1V" stopProcessing="true">
+					<match url="^(application|modules|system|tests|sql)"  />
+					<conditions>
+						<add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+						<add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
+					</conditions>
+					<action type="Rewrite" url="/-"  />
+				</rule>
+				<rule name="rule 2V" stopProcessing="true">
+					<match url=".*"  />
+					<conditions>
+						<add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+						<add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
+					</conditions>
+					<action type="Rewrite" url="/index.php?kohana_uri={R:0}"  appendQueryString="true" />
+				</rule>
+			</rules>
+		</rewrite>
+	</system.webServer>
+</configuration>
+	


### PR DESCRIPTION
...n Windows servers running under IIS

This change will allow you to host your ushahidi installation on
Windows Azure. This was not possible before and you could not host your
ushahidi installation on a Windows web server running IIS as the web
server because the .htaccess file only works on Apache and will not work
under IIS.
IIS howver will only parse the rewrite rules in a Web.config file.
Here I have put all the rewrite rules in the web.config file so that I
can be able to host my Ushahidi installation on Windows Azure.
