### PR TITLE
Fixing #1067: Undefined on hover

### DIFF
--- a/application/controllers/json.php
+++ b/application/controllers/json.php
@@ -239,7 +239,8 @@ class Json_Controller extends Template_Controller {
 				'thumb' => $thumb,
 				'timestamp' => strtotime($marker->incident_date),
 				'count' => 1,
-				'class' => get_class($marker)
+				'class' => get_class($marker),
+				'title'  => $marker->incident_title
 			);
 			$json_item['geometry'] = array(
 				'type' => 'Point',

--- a/media/js/ushahidi.js
+++ b/media/js/ushahidi.js
@@ -80,10 +80,18 @@
 				label:"${clusterCount}",
 				fontWeight: "${fontweight}",
 				fontColor: "#ffffff",
-				fontSize: "${fontsize}"
+				fontSize: "${fontsize}",
+				title: "${title}"    
 			},
 			{
 				context: {
+					title: function(feature) {
+            			if (feature.attributes.count >= 2) {
+              				return feature.attributes.count + " reports";
+            			} else {
+              				return feature.attributes.title;
+            			}
+          			},
 					count: function(feature) {
 						if (feature.attributes.count < 2) {
 							return 2 * Ushahidi.markerRadius;


### PR DESCRIPTION
Hover is based on element's 'title' attribute, which is really
consistently treated by browsers. Hover will now display number of
reports in case there's more than one report in cluster, and report name
otherwise.

Note: I've committed this change by mistake to Pull Request #1192. Sorry!
