### PR TITLE
Issue #1213 Fixing issue with Sharing plugin

### DIFF
--- a/application/controllers/json.php
+++ b/application/controllers/json.php
@@ -803,8 +803,8 @@ class Json_Controller extends Template_Controller {
 		foreach ($cluster as $marker)
 		{
 			// Handle both reports::fetch_incidents() response and actual ORM objects
-			$latitude = isset($marker->latitude) ? $marker->latitude : $marker->location->latitude;
-			$longitude = isset($marker->longitude) ? $marker->longitude : $marker->location->longitude;
+			$latitude = isset($marker["latitude"]) ? $marker["latitude"] : $marker["location"]["latitude"];
+			$longitude = isset($marker["longitude"]) ? $marker["longitude"] : $marker["location"]["longitude"];
 			
 			if ($latitude < $south)
 			{


### PR DESCRIPTION
Json_Controller::calculate_center() expecting marker to be an object but array being passed int by Share_Controller::index(). Not sure if an object is ever passed to calculate_center(), but this update shouldn't cause a problem as object properties are accessible using array syntax anyway.
