### PR TITLE
#1189: set_time_limit() when safe_mode = On

### DIFF
--- a/application/controllers/scheduler.php
+++ b/application/controllers/scheduler.php
@@ -26,10 +26,10 @@ class Scheduler_Controller extends Controller {
 
 		// Set time limit only if we're not on safe_mode
 		$safe_mode_enabled = ini_get('safe_mode');
-        if (empty($safe_mode_enabled))
-        {
+		if (empty($safe_mode_enabled))
+		{
 			set_time_limit(180);
-        }
+		}
 	}
 
 	public function index()


### PR DESCRIPTION
Checking if safe_mode is on before calling set_time_limit.

This means our scheduler can reach max_execution_time though. Not great, but at least our little scheduler will get a chance to try. :smile: 
