### PR TITLE
Normalising data for calculate_center() (Issue #1232)

### DIFF
--- a/application/controllers/json.php
+++ b/application/controllers/json.php
@@ -801,6 +801,9 @@ class Json_Controller extends Template_Controller {
 		$lat_sum = $lon_sum = 0;
 		foreach ($cluster as $marker)
 		{
+			// Normalising data
+			$marker = (array) $marker;
+
 			// Handle both reports::fetch_incidents() response and actual ORM objects
 			$latitude = isset($marker->latitude) ? $marker->latitude : $marker->location->latitude;
 			$longitude = isset($marker->longitude) ? $marker->longitude : $marker->location->longitude;


### PR DESCRIPTION
The sharing plugin passes arrays to the Json_controller::calculate_center() function, while it can come in as stdClass from a few other venues. This normalises it all to an array so the looks likes it.

This is somewhat a lazy solution, but transforming an array to an stdClass is not as straight forward. Also, this avoids re-writing other bits of code that call calculate_center(), which can introduce other bugs.

BTW, I'm **VERY** surprised this didn't come up during testing. It is fairly major.
