### PR TITLE
Fix json_controller::calculate_center() for both core and sharing plugin

### DIFF
--- a/application/controllers/json.php
+++ b/application/controllers/json.php
@@ -802,6 +802,12 @@ class Json_Controller extends Template_Controller {
 		$lat_sum = $lon_sum = 0;
 		foreach ($cluster as $marker)
 		{
+			// Normalising data
+			if (is_array($marker))
+			{
+				$marker = (object) $marker;
+			}
+
 			// Handle both reports::fetch_incidents() response and actual ORM objects
 			$latitude = isset($marker->latitude) ? $marker->latitude : $marker->location->latitude;
 			$longitude = isset($marker->longitude) ? $marker->longitude : $marker->location->longitude;


### PR DESCRIPTION
Building on #1233 and #1232 .. this normalizes `$marker` values in calculate_center() to objects.
