### PR TITLE
Fixing timeline js timing out (#483)

### DIFF
--- a/media/js/selectToUISlider.jQuery.js
+++ b/media/js/selectToUISlider.jQuery.js
@@ -212,7 +212,7 @@ jQuery.fn.selectToUISlider = function(settings){
 	.slider(options.sliderOptions)
 	.attr('role','application');
 
-	var labels = jQuery('.ui-slider-label');
+	var labels = jQuery('.ui-slider-label', sliderComponent);
 	var width = labels.width() / 2;
 	labels.css("marginLeft", width);
 


### PR DESCRIPTION
Issue is being caused by selectToUISlider() plugin. It calls a jQuery::width() on each of the elements it creates for the month names (it can go up to quite a few on large time spans)

Updated function to call jQuery::width() only on the first element of the set, and letting jQuery handle the css() call for the whole collection. I suspect it will use each() internally, but I also suspect it will have smarts to do it more efficiently.
