### PR TITLE
Updating MySQL distance calculations to use metric (#921)

### DIFF
--- a/application/models/incident.php
+++ b/application/models/incident.php
@@ -272,7 +272,10 @@ class Incident_Model extends ORM {
 		if (count($radius) > 0 AND array_key_exists('latitude', $radius) AND array_key_exists('longitude', $radius)
 			AND array_key_exists('distance', $radius))
 		{
-			// Calculate the distance of each point from the starting point
+
+			// Calculate the distance of each point from the starting point using Spherical Law of Cosines
+			// 60 = nautical miles per degree of latitude, 1.1515 miles in every nautical mile, 1.609344 km = 1 km
+			// more details about the math here: http://sgowtham.net/ramblings/2009/08/04/php-calculating-distance-between-two-locations-given-their-gps-coordinates/
 			$sql .= ", ((ACOS(SIN(%s * PI() / 180) * SIN(l.`latitude` * PI() / 180) + COS(%s * PI() / 180) * "
 				. "	COS(l.`latitude` * PI() / 180) * COS((%s - l.`longitude`) * PI() / 180)) * 180 / PI()) * 60 * 1.1515 * 1.609344) AS distance ";
 
@@ -392,6 +395,8 @@ class Incident_Model extends ORM {
 			unset ($location);
 
 			// Query to fetch the neighbour
+			// 60 = nautical miles per degree of latitude, 1.1515 miles in every nautical mile, 1.609344 km = 1 km
+			// more details about the math here: http://sgowtham.net/ramblings/2009/08/04/php-calculating-distance-between-two-locations-given-their-gps-coordinates/
 			$sql = "SELECT DISTINCT i.*, l.`latitude`, l.`longitude`, l.location_name, "
 				. "((ACOS(SIN( :lat * PI() / 180) * SIN(l.`latitude` * PI() / 180) + COS( :lat * PI() / 180) * "
 				. "	COS(l.`latitude` * PI() / 180) * COS(( :lon - l.`longitude`) * PI() / 180)) * 180 / PI()) * 60 * 1.1515 * 1.609344) AS distance "

--- a/tests/phpunit/classes/helpers/Reports_Test.php
+++ b/tests/phpunit/classes/helpers/Reports_Test.php
@@ -123,6 +123,11 @@ class Reports_Helper_Test extends PHPUnit_Framework_TestCase {
 		$table_prefix = Kohana::config('database.default.table_prefix');
 		
 		// Expected SQL statement; based on the $filter_params above
+
+		// Distance calculation deets:
+		// 60 = nautical miles per degree of latitude, 1.1515 miles in every nautical mile, 1.609344 km = 1 km
+		// more details about the math here: http://sgowtham.net/ramblings/2009/08/04/php-calculating-distance-between-two-locations-given-their-gps-coordinates/
+
 		$expected_sql = "SELECT DISTINCT i.id incident_id, i.incident_title, i.incident_description, i.incident_date, "
 				. "i.incident_mode, i.incident_active, i.incident_verified, i.location_id, l.country_id, l.location_name, l.latitude, l.longitude "
 				. ", ((ACOS(SIN(".$latitude." * PI() / 180) * SIN(l.`latitude` * PI() / 180) + COS(".$latitude." * PI() / 180) * "


### PR DESCRIPTION
MySQL geo distance calculation functions currently return results in miles instead of kms. Multiplying result of function by 1.609344 should fix the issue.

Dev Note: Tested with a few situations with the report search and report view pages, which seems to yield the correct results. However, I'm not entirely confident I was able to explore all use cases for the Incident::get_incidents() and Incident::get_neighbouring_incidents().
