### PR TITLE
Fixing logging for uncaught exceptions

### DIFF
--- a/system/core/Kohana.php
+++ b/system/core/Kohana.php
@@ -865,7 +865,7 @@ final class Kohana {
 		if ($level <= self::$configuration['core']['log_threshold'])
 		{
 			// Log the error
-			self::log('error', self::lang('core.uncaught_exception', $type, $message, $file, $line));
+			self::log('error', self::lang('core.uncaught_exception', array($type, $message, $file, $line)));
 		}
 
 		if ($PHP_ERROR)


### PR DESCRIPTION
Kohana's log function accepts an array of arguments, but the default exception handler doesn't really do that, which logs a whole bunch of useless messages.

This fixes that. :)
