### PR TITLE
Hack SwiftMailer to escape 'name' part of email addresses

### DIFF
--- a/system/vendor/swift/Swift/Address.php
+++ b/system/vendor/swift/Swift/Address.php
@@ -88,7 +88,10 @@ class Swift_Address extends Swift_AddressContainer
     {
       if (($this->name !== null))
       {
-        return $this->name . " <" . $this->address . ">";
+        //return $this->name . " <" . $this->address . ">";
+        // HACK: Add quotes and escaping on address name
+        return "\"" . addslashes($this->name) . "\" <" . $this->address . ">";
+        // END HACK
       }
       else return $this->address;
     }


### PR DESCRIPTION
This fixes intermittent issues with email alerts and other email sending.

Most emails in the platform send with FROM: sitename <siteemail>
However without any escaping then adding spaces and other characters (notable `:`) to the site name yields very weird results. For example something like
`My deployment: dev <dev@somedomain.com>` gets split into 3 email addresses..
