### PR TITLE
Fixing boolean check for stats (Issue #1270)

### DIFF
--- a/application/models/stats.php
+++ b/application/models/stats.php
@@ -519,7 +519,7 @@ STATSCOLLECTOR;
 
 		$xml = simplexml_load_string(Stats_Model::_curl_req($stat_url));
 
-		if($xml == false)
+		if ($xml === false)
 		{
 			return false;
 		}


### PR DESCRIPTION
eaf1a69 half fixed the issue with connection problems.

The check for $xml == false is always true, and so the stat_id and stat_key returned by the tracker are never saved on the database. This never lets new deployments get their stats started.
