### PR TITLE
Bug when updating email on /admin/profile (Issue #1260)

### DIFF
--- a/application/controllers/admin/profile.php
+++ b/application/controllers/admin/profile.php
@@ -79,11 +79,9 @@ class Profile_Controller extends Admin_Controller
                         $user->password = $post->new_password;
                     }
 					$user->save();
-					
-					
-					
+
 					Event::run('ushahidi_action.profile_edit', $user);
-						
+
 
 	                // We also need to update the RiverID server with the new password if
 	                //    we are using RiverID and a password is being passed
@@ -165,7 +163,7 @@ class Profile_Controller extends Admin_Controller
 		if (array_key_exists('current_password',$post->errors()))
 			return;
 
-		$user = User_Model::get_user_by_email($post->email);
+		$user = ORM::factory('user',$this->user_id);
 
 		if ( ! User_Model::check_password($user->email,$post->current_password) )
 		{


### PR DESCRIPTION
Code is loading user by email to check password typed. If user is updating their email password can never be verified. Changed code to load user by id in session instead.
