### PR TITLE
Fix inconsistency in custom fields position

### DIFF
--- a/application/models/form_field.php
+++ b/application/models/form_field.php
@@ -121,6 +121,19 @@ class Form_Field_Model extends ORM {
 		// Delete all responses associated with this field
 		ORM::factory('form_field_option')->where('form_field_id', $this->id)->delete_all();
 		
+		// Update other fields position
+		$fields = ORM::factory('form_field')
+			->where(array(
+				'form_id' => $this->form_id, 
+				'id != ' => $this->id, 
+				'field_position > ' => $this->field_position))
+			->find_all();
+		foreach($fields as $field)
+		{
+			$field->field_position = $field->field_position - 1;
+			$field->save();
+		}
+		
 		// Delete the field
 		parent::delete();
 	}


### PR DESCRIPTION
Hello,

The following actions in form manager will cause an inconsistency in custom fields positions, two or more fields will share the same position :
- Create some fields in a form (for having a sample)
- Delete any field (but NOT the last one)
- Add a new field

The last two fields will now share the same position (you can check in the database).

A fix like this one can resolve this bug, basically it decrease all the followings fields position before deleting the field.
