### PR TITLE
Add documentation node for PHP error_reporting level.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -136,6 +136,9 @@ Installation
 
     __NOTE: Your account must have all the privileges listed above in order to run Ushahidi on your webserver.__
 
+* ####Ensure PHP error_reporting level is compatable
+    As of PHP-5.4 Ushahidi doesn't work with the error_reporting level E_STRICT.  Ensure this level is excluded from the error_reporting configuration.
+
 * ####Run the install script
     To run the install script, point your browser to the base url of your website: (e.g. http://www.example.com).
     


### PR DESCRIPTION
When PHP's error_reporting level includes the E_STRICT level (2048) Ushahidi breaks and reports "Strict Mode Error" warnings and is unable to load any pages.

This PR only documents this issue.  The ideal solution would be to adhere to strict mode limitations, and as a second choice it would be to detect the E_STRICT error_reporting level and warn about this before displaying "Strict Mode Error".

Tested on Debian Wheezy with a custom built PHP-5.4.25 using PHP-FPM + Nginx.
