### PR TITLE
#1334 updated helper and schedular to add url in sms

### DIFF
--- a/application/controllers/admin/settings.php
+++ b/application/controllers/admin/settings.php
@@ -618,7 +618,8 @@ class Settings_Controller extends Admin_Controller {
 			'sms_provider' => '',
 			'sms_no1' => '',
 			'sms_no2' => '',
-			'sms_no3' => ''
+			'sms_no3' => '',
+			'sms_alert_url' => '' // HT: new setting for url on sms
 		);
 		//	Copy the form as errors, so the errors will be stored with keys
 		//	corresponding to the form field names
@@ -642,10 +643,13 @@ class Settings_Controller extends Admin_Controller {
 			$post->add_rules('sms_no1', 'numeric', 'length[1,30]');
 			$post->add_rules('sms_no2', 'numeric', 'length[1,30]');
 			$post->add_rules('sms_no3', 'numeric', 'length[1,30]');
+			$post->add_rules('sms_alert_url','required','between[0,1]'); // HT: new setting for url on sms
 
 			// Test to see if things passed the rule checks
 			if ($post->validate())
 			{
+				if(!Settings_Model::get_setting('sms_alert_url'))
+					Settings_Model::save_setting('sms_alert_url', $post->sms_alert_url);
 				// Yes! everything is valid
 				Settings_Model::save_all($post);
 
@@ -677,12 +681,14 @@ class Settings_Controller extends Admin_Controller {
 		{
 			$settings = Settings_Model::get_settings(array_keys($form))
 			;
+			$settings['sms_alert_url'] = (isset($settings['sms_alert_url'])) ? $settings['sms_alert_url'] : 0; // HT: might not be in database so calling manually return NULL if not exist
 			// Retrieve Current Settings
 			$form = array(
 				'sms_provider' => $settings['sms_provider'],
 				'sms_no1' => $settings['sms_no1'],
 				'sms_no2' => $settings['sms_no2'],
-				'sms_no3' => $settings['sms_no3']
+				'sms_no3' => $settings['sms_no3'],
+				'sms_alert_url' => $settings['sms_alert_url'] // HT: new setting for url on sms
 			);
 		}
 
@@ -690,6 +696,7 @@ class Settings_Controller extends Admin_Controller {
 		$this->template->content->errors = $errors;
 		$this->template->content->form_error = $form_error;
 		$this->template->content->form_saved = $form_saved;
+		$this->template->content->alert_url_array = array('1'=>Kohana::lang('ui_admin.yes'),'0'=>Kohana::lang('ui_admin.no'));
 
 		$this->template->content->sms_provider_array = array_merge(
 			array("" => "-- Select One --"),

--- a/application/controllers/alerts.php
+++ b/application/controllers/alerts.php
@@ -206,6 +206,8 @@ class Alerts_Controller extends Main_Controller {
 		$code = (isset($_GET['c']) AND !empty($_GET['c'])) ? $_GET['c'] : "";
 
 		$email = (isset($_GET['e']) AND !empty($_GET['e'])) ? $_GET['e'] : "";
+		// HT: Mobile verification by url
+		$mobile = (isset($_GET['m']) AND !empty($_GET['m'])) ? $_GET['m'] : "";
 
 		// INITIALIZE the content's section of the view
 		$this->template->content = new View('alerts/verify');
@@ -231,13 +233,17 @@ class Alerts_Controller extends Main_Controller {
 		}
 		else
 		{
-			if (empty($code) OR empty($email))
+			//if (empty($code) OR empty($email))
+			if (empty($code) OR (empty($email) AND empty($mobile)))
 			{
 				$missing_info = TRUE;
 			}
 			else
 			{
-				$filter = "alert.alert_type=2 AND alert_code='".Database::instance()->escape_str($code)."' AND alert_recipient='".Database::instance()->escape_str($email)."' ";
+				if(! empty($email)) // HT: condition to check email alert
+					$filter = "alert.alert_type=2 AND alert_code='".Database::instance()->escape_str($code)."' AND alert_recipient='".Database::instance()->escape_str($email)."' ";
+				elseif(! empty($mobile)) // HT: condition to check mobile alert
+				$filter = "alert.alert_type=1 AND alert_code='".Database::instance()->escape_str(utf8::strtoupper($code))."' AND alert_recipient='".Database::instance()->escape_str($mobile)."' ";
 			}
 		}
 

--- a/application/controllers/scheduler/s_alerts.php
+++ b/application/controllers/scheduler/s_alerts.php
@@ -114,7 +114,15 @@ class S_Alerts_Controller extends Controller {
 			// Remove line breaks
 			$sms_message = str_replace("\n", " ", $sms_message);
 			// Shorten to text message size
-			$sms_message = text::limit_chars($sms_message, 150, "...");
+			if(Kohana::config("settings.sms_alert_url"))
+			{
+				$sms_message = text::limit_chars($sms_message, 100, "..."); // HT: Decreased sms lenght of sms to add incident_url
+				$sms_message .= " ".$incident_url; // HT: Added incident_url to sms
+			}
+			else
+			{
+				$sms_message = text::limit_chars($sms_message, 150, "...");
+			}
 			
 			
 			

--- a/application/helpers/alert.php
+++ b/application/helpers/alert.php
@@ -30,11 +30,14 @@ class alert_Core {
 
 		// Should be 8 distinct characters
 		$alert_code = text::random('distinct', 8);
-
+		// HT: Mobile alert for link
+		$alert_mobile = $post->alert_mobile;
 		$sms_from = self::_sms_from();
 
 		$message = Kohana::lang('ui_admin.confirmation_code').$alert_code
 			.'.'.Kohana::lang('ui_admin.not_case_sensitive');
+		// HT: verify link for mobile
+		$message .= ' '.Kohana::lang('alerts.confirm_request').url::site().'alerts/verify?c='.$alert_code."&m=".$alert_mobile;
 	
 		if (sms::send($post->alert_mobile, $sms_from, $message) === true)
 		{

--- a/application/views/admin/settings/sms.php
+++ b/application/views/admin/settings/sms.php
@@ -77,6 +77,13 @@
 							<h4><?php echo Kohana::lang('ui_main.phone');?> 3: <span><?php echo Kohana::lang('settings.sms.flsms_text_2');?></span></h4>
 							<?php print form::input('sms_no3', $form['sms_no3'], ' class="text title_2"'); ?>
 						</div>
+						<div class="row">
+							<h4><?php echo Kohana::lang('ui_main.alert_url');?></h4>
+							<?php print form::dropdown('sms_alert_url', $alert_url_array, $form['sms_alert_url']); ?>
+						</div>
+						<span>
+							<?php echo Kohana::lang('settings.sms.alert_url_text');?>
+						</span>
 					</div>
 		
 					<div class="simple_border"></div>


### PR DESCRIPTION
incident url has been added to sms alert by shortening the current sms length to 100 and is configurable.
and it now also add url of alert subscription verification for mobile alert as it only used to give code and if sms deliver lately or if user had verified for email, user could have been unable to verify mobile.
