### PR TITLE
#1282 added parent_category list in edit report new category

### DIFF
--- a/application/controllers/admin/reports.php
+++ b/application/controllers/admin/reports.php
@@ -1139,6 +1139,20 @@ class Reports_Controller extends Admin_Controller {
 		if ($_POST)
 		{
 			// Instantiate Validation, use $post, so we don't overwrite $_POST fields with our own things
+			// HT: New code for category save with parent
+			$post = arr::extract($_POST, 'parent_id',
+					'category_title', 'category_description', 'category_color');
+
+			// Category instance for the operation
+			$category = new Category_Model();
+			if ($category->validate($post)) {
+				$category->save();
+				$form_saved = TRUE;
+
+				echo json_encode(array("status"=>"saved", "id"=>$category->id));
+			}
+			// HT: End of code for category save with parent
+			/*
 			$post = Validation::factory($_POST);
 
 			 //	Add some filters
@@ -1161,7 +1175,7 @@ class Reports_Controller extends Admin_Controller {
 				$form_saved = TRUE;
 
 				echo json_encode(array("status"=>"saved", "id"=>$category->id));
-			}
+			}*/
 			else
 			{
 				echo json_encode(array("status"=>"error"));
@@ -1211,10 +1225,25 @@ class Reports_Controller extends Admin_Controller {
 	// Dynamic categories form fields
 	private function _new_categories_form_arr()
 	{
+		// HT: Parent category list
+		$parents_array = ORM::factory('category')
+		->where('parent_id','0')
+		->where('category_trusted != 1')
+		->select_list('id', 'category_title');
+
+		// add none to the list
+		$parents_array[0] = "--- Top Level Category ---";
+
+		// Put "--- Top Level Category ---" at the top of the list
+		ksort($parents_array);
+		// HT: End of Parent category list
+
 		return array(
 			'category_name' => '',
 			'category_description' => '',
 			'category_color' => '',
+			'parent_id' => 0, // HT: new category parent
+			'category_parent_array' => $parents_array, // HT: new category parent
 		);
 	}
 

--- a/application/views/admin/reports/edit.php
+++ b/application/views/admin/reports/edit.php
@@ -169,6 +169,12 @@
                                     print '<br/>';
                                     print form::input('category_name', $new_categories_form['category_name'], 'class=""');
                                     print '<br/>';
+									// HT: Parent category on report edit
+									print form::label(array("id"=>"parent_id_label", "for"=>"parent_id"), Kohana::lang('ui_main.parent_category'));
+									print '<br/>';
+									print form::dropdown('category_parent_id', $new_categories_form['category_parent_array'], $new_categories_form['parent_id'], 'class=""');
+									print '<br/>';
+									// HT: End of Parent category on report edit
                                     print form::label(array("id"=>"description_label", "for"=>"description"), Kohana::lang('ui_main.description'));
                                     print '<br/>';
                                     print form::input('category_description', $new_categories_form['category_description'], 'class=""');

--- a/themes/default/views/reports/submit_edit_js.php
+++ b/themes/default/views/reports/submit_edit_js.php
@@ -391,7 +391,6 @@
 			});
 			
 			// Textbox Hints
-			$("#location_find").hint();
 			
 			/* Dynamic categories */
 			<?php if ($edit_mode): ?>
@@ -400,6 +399,7 @@
 		        var category_name = $("input#category_name").val();
 		        var category_description = $("input#category_description").val();
 		        var category_color = $("input#category_color").val();
+				var category_parent_id = $("select#category_parent_id").val(); // HT: Parent category in report edit new category
 
 				//trim the form fields
 				//Removed ".toUpperCase()" from name and desc for Ticket #38
@@ -421,7 +421,7 @@
 		        }
 		
 				$.post("<?php echo url::base() . 'admin/reports/save_category/' ?>", 
-					{ category_title: category_name, category_description: category_description, category_color: category_color },
+					{ category_title: category_name, category_description: category_description, category_color: category_color, parent_id : category_parent_id }, // HT: Parent category in report edit new category
 					function(data){
 						if ( data.status == 'saved')
 						{


### PR DESCRIPTION
Now it allows to append newly created category from incident edit page to be associated with parent category. Before it used to be saved as parent category and user would have to go to category list to move it to child level
