### PR TITLE
Delete cache after changing theme

### DIFF
--- a/application/controllers/admin/addons/themes.php
+++ b/application/controllers/admin/addons/themes.php
@@ -94,6 +94,8 @@ class Themes_Controller extends Admin_Controller {
 		$this->template->content->form_saved = $form_saved;
 		$themes = addon::get_addons('theme');	
 		$this->template->content->themes = $themes;
+		//delete cache to make sure theme is reloaded after change
+  		$this->cache->delete_all();
 	}
 
 }


### PR DESCRIPTION
After changing the theme, it delete's the cache to make sure the theme reloads immediately. This fixes issue #1352
