### PR TITLE
Stop checking what characters are in passwords, refs #1371, fixes #1372

### DIFF
--- a/application/controllers/admin/profile.php
+++ b/application/controllers/admin/profile.php
@@ -62,7 +62,7 @@ class Profile_Controller extends Admin_Controller
             // If Password field is not blank
             if ( ! empty($post->new_password))
             {
-                $post->add_rules('new_password','required','length[5,30]','alpha_dash','matches[password_again]');
+				$post->add_rules('new_password','required','length['.Kohana::config('auth.password_length').']','matches[password_again]');
             }
 		//for plugins that'd like to know what the user has to say about their profile
 		Event::run('ushahidi_action.profile_add_admin', $post);

--- a/application/controllers/login.php
+++ b/application/controllers/login.php
@@ -245,7 +245,7 @@ class Login_Controller extends Template_Controller {
 			//	Add some filters
 			$post->pre_filter('trim', TRUE);
 
-			$post->add_rules('password','required', 'length['.kohana::config('auth.password_length').']','alpha_dash');
+			$post->add_rules('password','required', 'length['.kohana::config('auth.password_length').']');
 			$post->add_rules('name','required','length[3,100]');
 			$post->add_rules('email','required','email','length[4,64]');
 			$post->add_callbacks('username', array($this,'username_exists_chk'));
@@ -255,7 +255,7 @@ class Login_Controller extends Template_Controller {
 			if ( ! empty($post->password))
 			{
 				$post->add_rules('password','required','length['.kohana::config('auth.password_length').']'
-					,'alpha_dash','matches[password_again]');			
+					,'matches[password_again]');			
 			}
 			//pass the post object to any plugins that care to know.
 			Event::run('ushahidi_action.users_add_login_form', $post);
@@ -389,8 +389,8 @@ class Login_Controller extends Template_Controller {
 			$post->pre_filter('trim', TRUE);
 			$post->add_rules('token','required');
 			$post->add_rules('changeid','required');
-			$post->add_rules('password','required','length['.Kohana::config('auth.password_length').']','alpha_dash');
-			$post->add_rules('password','required','length['.Kohana::config('auth.password_length').']','alpha_dash','matches[password_again]');
+			$post->add_rules('password','required','length['.Kohana::config('auth.password_length').']');
+			$post->add_rules('password','required','length['.Kohana::config('auth.password_length').']','matches[password_again]');
 
 			if ($post->validate())
 			{

--- a/application/controllers/members/profile.php
+++ b/application/controllers/members/profile.php
@@ -72,7 +72,7 @@ class Profile_Controller extends Members_Controller
 			// If Password field is not blank
 			if ( ! empty($post->new_password))
 			{
-				$post->add_rules('new_password','required','length['.kohana::config('auth.password_length').']' ,'alpha_dash','matches[password_again]');	
+				$post->add_rules('new_password','required','length['.kohana::config('auth.password_length').']','matches[password_again]');	
 			}
 			//for plugins that want to know what the user had to say about things
 			Event::run('ushahidi_action.profile_post_member', $post);

--- a/application/models/user.php
+++ b/application/models/user.php
@@ -159,16 +159,14 @@ class User_Model extends Auth_User_Model {
 		// Only check for the password if the user id has been specified and we are passing a pw
 		if (isset($post->user_id) AND isset($post->password))
 		{
-			$post->add_rules('password','required', 'alpha_dash', 'length['.$password_length.']');
-			$post->add_callbacks('password' ,'User_Model::validate_password');
+			$post->add_rules('password','required', 'length['.$password_length.']');
 		}
 
 		// If Password field is not blank and is being passed
 		if ( isset($post->password) AND
 			(! empty($post->password) OR (empty($post->password) AND ! empty($post->password_again))))
 		{
-			$post->add_rules('password','required', 'alpha_dash','length['.$password_length.']', 'matches[password_again]');
-			$post->add_callbacks('password' ,'User_Model::validate_password');
+			$post->add_rules('password','required','length['.$password_length.']', 'matches[password_again]');
 		}
 
 		$post->add_rules('role','required','length[3,30]', 'alpha_numeric');
@@ -246,22 +244,6 @@ class User_Model extends Auth_User_Model {
 		{
 			$post->add_error($field, 'superadmin_modify');
 		}
-	}
-
-	public static function validate_password(Validation $post, $field)
-	{
-		$_is_valid = User_Model::password_rule($post[$field]);
-		if (! $_is_valid)
-		{
-			$post->add_error($field,'alpha_dash');
-		}
-	}
-
-	public static function password_rule($password, $utf8 = FALSE)
-	{
-		return ($utf8 === TRUE)
-			? (bool) preg_match('/^[-\pL\pN#@_]++$/uD', (string) $password)
-			: (bool) preg_match('/^[-a-z0-9#@_]++$/iD', (string) $password);
 	}
 
 	/*


### PR DESCRIPTION
#285 changed password validation from `alpha_numeric` to `alpha_dash` to solve a problem with the validation message, but (functionally) all this did was add the characters `_-` to the allowed list, which still prevents special characters from being used.

As noted by @rjmackay on #285, the real goal is to allow **any** characters to be used for passwords. (This is shown by #1371.) Right now, only letters, numbers, dash, and underscore can be used, but the restriction is arbitrary, as the end result is that all passwords are hashed, making the character set irrelevant.
