### PR TITLE
Invalid use of "break"

### DIFF
--- a/application/libraries/VideoEmbed.php
+++ b/application/libraries/VideoEmbed.php
@@ -97,8 +97,9 @@ class VideoEmbed
 		{
 			$components = parse_url($raw);
 			parse_str($components['query'], $query);
-			if (! isset($query[$this->service['keep-params']]) ) break;
-			$raw = $this->service['baseurl']. $query[$this->service['keep-params']];
+			if ( isset($query[$this->service['keep-params']]) ){
+				$raw = $this->service['baseurl']. $query[$this->service['keep-params']];
+			}
 		}
 
 		return $raw;


### PR DESCRIPTION
A fix for the below error:
Fatal error: 'break' not in the 'loop' or 'switch' context in /home/forge/in-demo.ozbot.org/application/libraries/VideoEmbed.php on line 100